### PR TITLE
DISCUSSION-47: Allow to specify a user creator of the discussion doc using metadata

### DIFF
--- a/discussions-api/src/main/java/org/xwiki/contrib/discussions/DiscussionStoreConfigurationParameters.java
+++ b/discussions-api/src/main/java/org/xwiki/contrib/discussions/DiscussionStoreConfigurationParameters.java
@@ -34,6 +34,24 @@ import org.xwiki.stability.Unstable;
 public class DiscussionStoreConfigurationParameters extends LinkedHashMap<String, Object>
 {
     /**
+     * Defines the creator to use for the discussion technical pages: a {@code UserReference} need to be used.
+     * @since 2.4
+     */
+    public static final String CREATOR_PARAMETER_KEY = "creator";
+
+    /**
+     * Defines the effective author to use for the discussion technical pages: a {@code UserReference} need to be used.
+     * @since 2.4
+     */
+    public static final String EFFECTIVE_AUTHOR_PARAMETER_KEY = "effectiveAuthor";
+
+    /**
+     * Defines the original author to use for the discussion technical pages: a {@code UserReference} need to be used.
+     * @since 2.4
+     */
+    public static final String ORIGINAL_AUTHOR_PARAMETER_KEY = "originalAuthor";
+
+    /**
      * Default constructor.
      */
     public DiscussionStoreConfigurationParameters()

--- a/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DefaultDiscussionContextStoreService.java
+++ b/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DefaultDiscussionContextStoreService.java
@@ -85,6 +85,9 @@ public class DefaultDiscussionContextStoreService extends AbstractDiscussionCont
     @Inject
     private DocumentRedirectionManager documentRedirectionManager;
 
+    @Inject
+    private DocumentAuthorsManager documentAuthorsManager;
+
     @Override
     public Optional<DiscussionContextReference> create(String applicationHint, String name, String description,
         DiscussionContextEntityReference entityReference,
@@ -111,6 +114,7 @@ public class DefaultDiscussionContextStoreService extends AbstractDiscussionCont
             object.setDateValue(CREATION_DATE_NAME, new Date());
             object.setDateValue(UPDATE_DATE_NAME, new Date());
             document.setHidden(true);
+            this.documentAuthorsManager.setDocumentAuthors(document.getAuthors(), null, configurationParameters);
             this.documentRedirectionManager.handleCreatingRedirection(document, configurationParameters);
             context.getWiki().saveDocument(document, context);
 

--- a/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DefaultDiscussionStoreService.java
+++ b/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DefaultDiscussionStoreService.java
@@ -98,6 +98,9 @@ public class DefaultDiscussionStoreService implements DiscussionStoreService
     @Inject
     private DocumentRedirectionManager documentRedirectionManager;
 
+    @Inject
+    private DocumentAuthorsManager documentAuthorsManager;
+
     @Override
     public Optional<DiscussionReference> create(String applicationHint, String title, String description,
         String mainDocument, DiscussionStoreConfigurationParameters configurationParameters)
@@ -118,7 +121,7 @@ public class DefaultDiscussionStoreService implements DiscussionStoreService
             object.setDateValue(CREATION_DATE_NAME, value);
             object.setStringValue(MAIN_DOCUMENT_NAME, mainDocument);
             document.setHidden(true);
-
+            documentAuthorsManager.setDocumentAuthors(document.getAuthors(), null, configurationParameters);
             this.documentRedirectionManager.handleCreatingRedirection(document, configurationParameters);
             context.getWiki().saveDocument(document, context);
             result = Optional.of(reference);

--- a/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DocumentAuthorsManager.java
+++ b/discussions-store/discussions-store-default/src/main/java/org/xwiki/contrib/discussions/store/internal/DocumentAuthorsManager.java
@@ -1,0 +1,81 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.discussions.store.internal;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.discussions.DiscussionStoreConfigurationParameters;
+import org.xwiki.contrib.discussions.domain.references.ActorReference;
+import org.xwiki.model.document.DocumentAuthors;
+import org.xwiki.user.GuestUserReference;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
+
+/**
+ * A utility component for setting the authors of discussion pages based on the parameters.
+ *
+ * @version $Id$
+ * @since 2.4
+ */
+@Component(roles = DocumentAuthorsManager.class)
+@Singleton
+public class DocumentAuthorsManager
+{
+    @Inject
+    private UserReferenceResolver<String> stringUserReferenceResolver;
+
+    /**
+     * Set the authors based on the parameters and on the actor reference.
+     * This method doesn't return anything but modifies the given {@link DocumentAuthors}.
+     * @param documentAuthors the authors to be set
+     * @param actorReference an actor reference to use as fallback if no parameter is given, this parameter can be
+     *                      {@code null}
+     * @param parameters the parameters to look for the author information
+     */
+    public void setDocumentAuthors(DocumentAuthors documentAuthors, ActorReference actorReference,
+        DiscussionStoreConfigurationParameters parameters)
+    {
+        if (documentAuthors.getCreator() == null || GuestUserReference.INSTANCE.equals(documentAuthors.getCreator())) {
+            getReference(actorReference, parameters, DiscussionStoreConfigurationParameters.CREATOR_PARAMETER_KEY)
+                .ifPresent(documentAuthors::setCreator);
+        }
+        getReference(actorReference, parameters, DiscussionStoreConfigurationParameters.EFFECTIVE_AUTHOR_PARAMETER_KEY)
+            .ifPresent(documentAuthors::setEffectiveMetadataAuthor);
+        getReference(actorReference, parameters, DiscussionStoreConfigurationParameters.ORIGINAL_AUTHOR_PARAMETER_KEY)
+            .ifPresent(documentAuthors::setOriginalMetadataAuthor);
+    }
+
+    private Optional<UserReference> getReference(ActorReference actorReference,
+        DiscussionStoreConfigurationParameters parameters, String key)
+    {
+        Optional<UserReference> result = Optional.empty();
+        if (parameters.containsKey(key) && parameters.get(key) instanceof UserReference) {
+            result = Optional.of((UserReference) parameters.get(key));
+        } else if (actorReference != null && StringUtils.equals(actorReference.getType(), "user")) {
+            result = Optional.of(this.stringUserReferenceResolver.resolve(actorReference.getReference()));
+        }
+        return result;
+    }
+}

--- a/discussions-store/discussions-store-default/src/main/resources/META-INF/components.txt
+++ b/discussions-store/discussions-store-default/src/main/resources/META-INF/components.txt
@@ -8,6 +8,7 @@ org.xwiki.contrib.discussions.store.internal.initializer.MessageXClassInitialize
 org.xwiki.contrib.discussions.store.internal.initializer.DiscussionContextMetadataXClassInitializer
 org.xwiki.contrib.discussions.store.internal.DefaultDiscussionStoreConfiguration
 org.xwiki.contrib.discussions.store.internal.DiscussionStoreConfigurationFactory
+org.xwiki.contrib.discussions.store.internal.DocumentAuthorsManager
 org.xwiki.contrib.discussions.store.internal.DefaultMessageHolderReferenceService
 org.xwiki.contrib.discussions.store.internal.PageHolderReferenceFactory
 org.xwiki.contrib.discussions.store.internal.DefaultDiscussionContextMetadataStoreService


### PR DESCRIPTION

  * Define new constants in DiscussionStoreConfigurationParameters to allow defining authors of the technical pages
  * Provide a utility component to set the authors based on the parameters
  * Use the new component in the various component saving pages